### PR TITLE
Fix K09 Unit test to meet autograder style

### DIFF
--- a/tests/testthat/test-K09_ggplot_aes.R
+++ b/tests/testthat/test-K09_ggplot_aes.R
@@ -24,14 +24,14 @@ test_that("K09: Question 4", {
   skip_incomplete(K09, 4)
   p <- parse_eval(str_match_q(K09, 4))
 
-  expect_equal(rlang::as_label(p$mapping$shape), "continent")
+  expect_equal(rlang::as_label(p$layers[[1]]$mapping$shape), "continent")
 })
 
 test_that("K09: Question 5", {
   skip_incomplete(K09, 5)
   p <- parse_eval(str_match_q(K09, 5))
 
-  expect_equal(rlang::as_label(p$mapping$colour), "continent")
-  expect_equal(rlang::as_label(p$mapping$size),   "pop")
+  expect_equal(rlang::as_label(p$layers[[1]]$mapping$colour), "continent")
+  expect_equal(rlang::as_label(p$layers[[1]]$mapping$size),   "pop")
 })
 


### PR DESCRIPTION
Test Updates (tests/testthat/test-K09_ggplot_aes.R)

  - Question 4: Changed test to check p$layers[[1]]$mapping$shape instead of p$mapping$shape
  - Question 5: Changed test to check p$layers[[1]]$mapping$colour and p$layers[[1]]$mapping$size instead of top-level mappings

  This allows students to learn the more flexible pattern of placing aesthetic mappings at the geom layer, which is particularly useful when working with multiple geom layers.